### PR TITLE
Update for Onnx Convert() documentation, limited to ONNX-ML

### DIFF
--- a/dotnet/xml/Microsoft.ML.Models/OnnxConverter.xml
+++ b/dotnet/xml/Microsoft.ML.Models/OnnxConverter.xml
@@ -58,11 +58,10 @@
           <see href="https://onnx.ai/">ONNX</see> is an intermediate representation format 
              for machine learning models. It is used to make models portable such that you can 
              train a model using a toolkit and run it in another tookit's runtime, for example,
-             you can create a model using ML.NET (or any ONNX compatible toolkit), convert it to ONNX and 
-             then the ONNX model can be converted into say, CoreML, TensorFlow or WinML model 
-             to run on the respective runtime.
+             you can create a model using ML.NET (or any ONNX compatible toolkit), convert it to ONNX-ML and 
+             then load, convert and run that ONNX model in Windows ML, on an UWP Windows 10 app.
              
-             This API converts an ML.NET model to ONNX format by inspecting the transform pipeline 
+             This API converts an ML.NET model to ONNX-ML format by inspecting the transform pipeline 
              from the end, checking for components that know how to save themselves as ONNX. 
              The first item in the transform pipeline that does not know how to save itself 
              as ONNX, is considered the "input" to the ONNX pipeline. (Ideally this would be the 


### PR DESCRIPTION
Afaik, current version of ML.NET Convert() to ONNX supports just ONNX-ML. This is an update for Onnx Convert() documentation so it is limited to ONNX-ML behavior when mentioning examples. ONNX-ML is currently supported only by WinML. 

CoreML and additional Onnx Backends might come in the future, though.

ONNX-ML is part of the ONNX standard that provides functionality for classic ML and pipelines. It is a superset of core ONNX. Many frameworks like Caffe2 and CNTK will not support ONNX-ML since they are focused on DNN. 
AWS, Yahoo, and others have expressed interest in ONNX-ML but their products do not currently support it. This might change in the future. Export through ONNX-CoreML converter should be possible in the future, as well.

## Summary

I eliminated references to CoreML and TensorFlow and left an example related to the currently supported target platforms by ONNX-ML which is WinML.

Fixes dotnet/docs#Issue_Number (if available)
