### PR TITLE
disable edit button

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -10,7 +10,6 @@
       ],
       "moniker_ranges": [],
       "open_to_public_contributors": false,
-      "git_repository_branch_open_to_public_contributors": "master",
       "type_mapping": {
         "Conceptual": "Content",
         "ManagedReference": "Content",

--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -9,7 +9,7 @@
         "ml-dotnet"
       ],
       "moniker_ranges": [],
-      "open_to_public_contributors": true,
+      "open_to_public_contributors": false,
       "git_repository_branch_open_to_public_contributors": "master",
       "type_mapping": {
         "Conceptual": "Content",


### PR DESCRIPTION
Given that this repo content is auto-generated from source, I believe we should disable the edit button, otherwise, people submit PRs to fix errors here instead of the source code.