### PR TITLE
configuring the repostitory to be able to reference cs files from https://github.com/dotnet/machinelearning/docs/samples

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -44,6 +44,12 @@
       "url": "https://github.com/Microsoft/templates.docs.msft",
       "branch": "master",
       "branch_mapping": {}
+    },
+    {
+      "path_to_root": "docs/samples",
+      "url": "https://github.com/dotnet/machinelearning",
+      "branch": "master",
+      "branch_mapping": {}
     }
   ],
   "need_generate_pdf_url_template": false,


### PR DESCRIPTION
Enabling the machine learning xml documentation to reference samples in CS files. 