### PR TITLE
Add latex support to docfx options

### DIFF
--- a/dotnet/docfx.json
+++ b/dotnet/docfx.json
@@ -63,7 +63,8 @@
       "ms.prod": "dotnet-ml-api",
       "feedback_system": "GitHub",
       "feedback_github_repo": "dotnet/machinelearning",
-      "feedback_product_url": "https://github.com/dotnet/machinelearning"
+      "feedback_product_url": "https://github.com/dotnet/machinelearning",
+      "show_latex": true
     },
     "fileMetadata": {},
     "template": [],


### PR DESCRIPTION
## Summary

Add show_latex: true to the globalMetaData options.

To add latex format to markdown formatted code comments, enclose them in $  $


