### PR TITLE
Fix LogLossReduction example value

### DIFF
--- a/dotnet/xml/Microsoft.ML.Data/MulticlassClassificationMetrics.xml
+++ b/dotnet/xml/Microsoft.ML.Data/MulticlassClassificationMetrics.xml
@@ -94,7 +94,7 @@
             The log-loss reduction is scaled relative to a classifier that predicts the prior for every example:
             (LL(prior) - LL(classifier)) / LL(prior)
             This metric can be interpreted as the advantage of the classifier over a random prediction.
-            For example, if the RIG equals 20, it can be interpreted as "the probability of a correct prediction is
+            For example, if the RIG equals 0.2, it can be interpreted as "the probability of a correct prediction is
             20% better than random guessing".
             </remarks>
       </Docs>


### PR DESCRIPTION
Minor LogLossReduction (RIG) example value fix.

Fixes dotnet/machinelearning#4097
