### PR TITLE
Changes to API docs for ML.Net 1.4

### DIFF
--- a/dotnet/xml/Microsoft.ML.Vision/ImageClassificationTrainer.xml
+++ b/dotnet/xml/Microsoft.ML.Vision/ImageClassificationTrainer.xml
@@ -22,7 +22,7 @@
              </summary>
     <remarks>
       <format type="text/markdown"><![CDATA[
-             To create this trainer, use [ImageClassification](xref:Microsoft.ML.Vision.DnnCatalog.ImageClassification(Microsoft.ML.MulticlassClassificationCatalog.MulticlassClassificationTrainers,System.String,System.String,System.String,System.String,Microsoft.ML.IDataView)).
+             To create this trainer, use [ImageClassification](xref:Microsoft.ML.VisionCatalog.ImageClassification(Microsoft.ML.MulticlassClassificationCatalog.MulticlassClassificationTrainers,System.String,System.String,System.String,System.String,Microsoft.ML.IDataView)).
             
              ### Input and Output Columns
              The input label column data must be[key] (xref:Microsoft.ML.Data.KeyDataViewType) type and the feature column must be a variable-sized vector of<xref:System.Byte>.

--- a/dotnet/xml/Microsoft.ML/VisionCatalog.xml
+++ b/dotnet/xml/Microsoft.ML/VisionCatalog.xml
@@ -13,8 +13,8 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Class used by <see cref="T:Microsoft.ML.MLContext" /> to create instances of image classification components.</summary>
+    <remarks>This requires additional nuget dependencies to link against Tensorflow native dlls.<see cref="T:Microsoft.ML.Vision.ImageClassificationTrainer"/></remarks>
   </Docs>
   <Members>
     <Member MemberName="ImageClassification">
@@ -39,12 +39,8 @@
         <param name="options">An <see cref="T:Microsoft.ML.Vision.ImageClassificationTrainer.Options" /> object specifying advanced
             options for <see cref="T:Microsoft.ML.Vision.ImageClassificationTrainer" />.</param>
         <summary>
-            Performs image classification using transfer learning.
-            Usage of this API requires additional NuGet dependencies on TensorFlow redist, see linked document
-            for more information.
-            <format type="text/markdown"><![CDATA[
-            [!include[io](~/../docs/samples/docs/api-reference/tensorflow-usage.md)]
-            ]]></format></summary>
+            Create <see cref="Microsoft.ML.Vision.ImageClassificationTrainer"/> using advanced options, which trains a Deep Neural Network(DNN) to classify images.
+        </summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
       </Docs>
@@ -79,12 +75,8 @@
         <param name="predictedLabelColumnName">The name of the output predicted label columns.</param>
         <param name="validationSet">The validation set used while training to improve model quality.</param>
         <summary>
-            Performs image classification using transfer learning.
-            Usage of this API requires additional NuGet dependencies on TensorFlow redist, see linked document for
-            more information.
-            <format type="text/markdown"><![CDATA[
-            [!include[io](~/../docs/samples/docs/api-reference/tensorflow-usage.md)]
-            ]]></format></summary>
+            Create <see cref="Microsoft.ML.Vision.ImageClassificationTrainer"/>, which trains a Deep Neural Network(DNN) to classify images.
+        </summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
       </Docs>


### PR DESCRIPTION
1. Changed the summary in VisionCatalog.xml. Removed the .md file.
2. Corrected the wrongly referenced link in ImageClassificationTrainer.xml. 