### PR TITLE
Fix broken link format

### DIFF
--- a/dotnet/xml/Microsoft.ML.Transforms.Text/TextFeaturizingEstimator.xml
+++ b/dotnet/xml/Microsoft.ML.Transforms.Text/TextFeaturizingEstimator.xml
@@ -39,7 +39,7 @@
              * [Predefined and custom stopwords removal](https://en.wikipedia.org/wiki/Stop_words)
              * [Word-based or character-based Ngram extraction and SkipGram extraction](https://en.wikipedia.org/wiki/N-gram) (through the advanced [options](xref:Microsoft.ML.Transforms.TextFeaturizingEstimator.Options.WordFeatureExtractor))
              * [TF, IDF or TF-IDF](https://en.wikipedia.org/wiki/Tf%E2%80%93idf)
-             * [L-p vector normalization](xref: Microsoft.ML.Transforms.LpNormNormalizingTransformer)
+             * [L-p vector normalization](xref:Microsoft.ML.Transforms.LpNormNormalizingTransformer)
             
              By default the features are made of (word/character) n-grams/skip-grams​ and the number of features are equal to the vocabulary size found by analyzing the data.
              To output an additional column with the tokens generated, use [OutputTokensColumnName](xref:Microsoft.ML.Transforms.Text.TextFeaturizingEstimator.Options.OutputTokensColumnName).

--- a/dotnet/xml/Microsoft.ML.Transforms.Text/TextFeaturizingEstimator.xml
+++ b/dotnet/xml/Microsoft.ML.Transforms.Text/TextFeaturizingEstimator.xml
@@ -37,7 +37,7 @@
              * [Tokenization](https://en.wikipedia.org/wiki/Lexical_analysis#Tokenization)
              * [Text normalization](https://en.wikipedia.org/wiki/Text_normalization)
              * [Predefined and custom stopwords removal](https://en.wikipedia.org/wiki/Stop_words)
-             * [Word-based or character-based Ngram extraction and SkipGram extraction (through the advanced [options](xref:Microsoft.ML.Transforms.TextFeaturizingEstimator.Options.WordFeatureExtractor))](https://en.wikipedia.org/wiki/N-gram)
+             * [Word-based or character-based Ngram extraction and SkipGram extraction](https://en.wikipedia.org/wiki/N-gram) (through the advanced [options](xref:Microsoft.ML.Transforms.TextFeaturizingEstimator.Options.WordFeatureExtractor))
              * [TF, IDF or TF-IDF](https://en.wikipedia.org/wiki/Tf%E2%80%93idf)
              * [L-p vector normalization](xref: Microsoft.ML.Transforms.LpNormNormalizingTransformer)
             


### PR DESCRIPTION
I noticed a broken link format on this page:
https://learn.microsoft.com/dotnet/api/microsoft.ml.transforms.text.textfeaturizingestimator?view=ml-dotnet

The bullet had a nested link, which doesn't render correctly.